### PR TITLE
refactor(messaging): post data through one-time requests

### DIFF
--- a/apps/ai-assistant/src/content-scripts/app.tsx
+++ b/apps/ai-assistant/src/content-scripts/app.tsx
@@ -7,7 +7,7 @@ import {
   isSelectionValid,
   rangeToReference,
 } from '@webx-kit/runtime/content-scripts';
-import { createTrpcHandler } from '@webx-kit/messaging/content-script';
+import { createTrpcClient } from '@webx-kit/messaging/content-script';
 import clsx from 'clsx';
 import type { AppRouter } from '@/background/router';
 import { DialogTrigger, TooltipTrigger } from 'react-aria-components';
@@ -15,7 +15,7 @@ import { Button, Popover, Tooltip } from '@/components';
 import { Provider } from './features/provider';
 import './global.less';
 
-const { client } = createTrpcHandler<AppRouter>({});
+const { client } = createTrpcClient<AppRouter>({});
 
 export const App = () => {
   const [visible, setVisible] = useState(false);

--- a/packages/messaging/demo/background/index.ts
+++ b/packages/messaging/demo/background/index.ts
@@ -2,11 +2,12 @@ import { createCustomHandler } from '@/background';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const { connections } = createCustomHandler({
+// @ts-expect-error
+globalThis.__messaging = createCustomHandler({
   async requestHandler(message) {
     return {
       reply: 'background',
-      data: message.data,
+      data: message,
     };
   },
   async streamHandler(_message, subscriber) {
@@ -19,6 +20,3 @@ const { connections } = createCustomHandler({
     subscriber.complete();
   },
 });
-
-// @ts-expect-error
-globalThis.__webxConnections = connections;

--- a/packages/messaging/demo/content-scripts/index.ts
+++ b/packages/messaging/demo/content-scripts/index.ts
@@ -6,7 +6,7 @@ const { messaging } = createCustomHandler({
   requestHandler(message) {
     return {
       reply: 'content-script',
-      data: message.data,
+      data: message,
     };
   },
   async streamHandler(_message, subscriber) {
@@ -21,4 +21,4 @@ const { messaging } = createCustomHandler({
 });
 
 // @ts-expect-error
-globalThis.__client = messaging;
+globalThis.__clientMessaging = messaging;

--- a/packages/messaging/demo/pages/options/index.ts
+++ b/packages/messaging/demo/pages/options/index.ts
@@ -7,7 +7,7 @@ const { messaging } = createCustomHandler({
   requestHandler(message) {
     return {
       reply: 'options',
-      data: message.data,
+      data: message,
     };
   },
   async streamHandler(_message, subscriber) {
@@ -22,4 +22,4 @@ const { messaging } = createCustomHandler({
 });
 
 // @ts-expect-error
-globalThis.__client = messaging;
+globalThis.__clientMessaging = messaging;

--- a/packages/messaging/demo/pages/popup/index.ts
+++ b/packages/messaging/demo/pages/popup/index.ts
@@ -7,7 +7,7 @@ const { messaging } = createCustomHandler({
   requestHandler(message) {
     return {
       reply: 'popup',
-      data: message.data,
+      data: message,
     };
   },
   async streamHandler(_message, subscriber) {
@@ -22,4 +22,4 @@ const { messaging } = createCustomHandler({
 });
 
 // @ts-expect-error
-globalThis.__client = messaging;
+globalThis.__clientMessaging = messaging;

--- a/packages/messaging/e2e/basic.spec.ts
+++ b/packages/messaging/e2e/basic.spec.ts
@@ -1,43 +1,54 @@
 import { setupStaticServer } from '@webx-kit/test-utils/playwright';
 import { expect, test } from './context';
 import type { Messaging } from '@/core';
-import type { WrappedMessaging } from '@/client-base';
+import type { WrappedMessaging } from '@/shared';
 
 const getWebpageURL = setupStaticServer(test);
 
 declare module globalThis {
   /** only in background */
-  const __webxConnections: Set<Messaging> | undefined;
-  const __client: WrappedMessaging;
+  const __messaging: Messaging;
+  const __clientMessaging: WrappedMessaging;
 }
 
 test('Background', async ({ background }) => {
-  await expect(background.evaluate(() => typeof globalThis.__webxConnections)).resolves.toBe('object');
+  await expect(background.evaluate(() => typeof globalThis.__messaging)).resolves.toBe('object');
 });
 
 test('Messaging', async ({ context, getURL }) => {
   const optionsPage = await context.newPage();
   const popupPage = await context.newPage();
-  const contentScript = await context.newPage();
+  const contentPage = await context.newPage();
 
   await Promise.all([
     optionsPage.goto(await getURL('options.html')),
     popupPage.goto(await getURL('popup.html')),
-    contentScript.goto(getWebpageURL()),
+    contentPage.goto(getWebpageURL()),
   ]);
 
-  await expect(optionsPage.evaluate(() => globalThis.__client.request('options', 'popup'))).resolves.toEqual({
-    reply: 'popup',
+  await expect(optionsPage.evaluate(() => globalThis.__clientMessaging.request('options'))).resolves.toEqual({
+    reply: 'background',
     data: 'options',
   });
 
-  await expect(popupPage.evaluate(() => globalThis.__client.request('popup', 'options'))).resolves.toEqual({
+  await expect(popupPage.evaluate(() => globalThis.__clientMessaging.requestTo('options', 'popup'))).resolves.toEqual({
     reply: 'options',
     data: 'popup',
   });
 
+  const [webpage] = await popupPage.evaluate(() =>
+    chrome.tabs.query({}).then((tabs) =>
+      tabs
+        .filter((tab) => tab.url?.startsWith('http'))
+        .map((tab) => ({
+          id: tab.id,
+          url: tab.url,
+        }))
+    )
+  );
+
   await expect(
-    popupPage.evaluate(() => globalThis.__client.request('popup to content-script', 'content-script'))
+    popupPage.evaluate((tabId) => globalThis.__clientMessaging.requestTo(tabId!, 'popup to content-script'), webpage.id)
   ).resolves.toEqual({
     reply: 'content-script',
     data: 'popup to content-script',
@@ -52,7 +63,7 @@ test('Stream', async ({ context, getURL }) => {
   const result = await optionsPage.evaluate(() => {
     return new Promise<unknown[]>((resolve, reject) => {
       const result: unknown[] = [];
-      globalThis.__client.stream('options', {
+      globalThis.__clientMessaging.stream('options', {
         next: (value) => result.push(value),
         error: reject,
         complete: () => resolve(result),

--- a/packages/messaging/playwright.config.ts
+++ b/packages/messaging/playwright.config.ts
@@ -6,4 +6,5 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './e2e',
   retries: 2,
+  timeout: 5000,
 });

--- a/packages/messaging/src/background.ts
+++ b/packages/messaging/src/background.ts
@@ -1,93 +1,46 @@
 import { AnyTRPCRouter } from '@trpc/server';
-import { Messaging, createMessaging, fromChromePort } from './core';
+import { Port, RequestHandler, StreamHandler, createMessaging } from './core';
 import { applyMessagingHandler } from './core/trpc';
-import { NAMESPACE, RequestHandler, StreamHandler, WebxMessage, isWebxMessage } from './shared';
-
-export type WebxMessageMiddleware = (
-  message: WebxMessage,
-  port: chrome.runtime.Port
-) => WebxMessage | false | void | Promise<WebxMessage | false | void>;
-
-// #region middlewares
-const senderInfoMiddleware: WebxMessageMiddleware = (message, port) => {
-  return {
-    from: port.name.slice(NAMESPACE.length),
-    tabId: port.sender?.tab?.id,
-    ...message,
-  };
-};
-// #endregion
-
-const middlewares = new Set<WebxMessageMiddleware>([senderInfoMiddleware]);
-
-async function applyMiddlewares(message: WebxMessage, port: chrome.runtime.Port) {
-  for (const middleware of middlewares) {
-    const modifiedMessage = await middleware(message, port);
-    if (modifiedMessage === false) return message;
-    if (modifiedMessage) message = modifiedMessage;
-  }
-  return message;
-}
+import { WebxMessage, isWebxMessage } from './shared';
 
 export interface CustomHandlerOptions {
   requestHandler?: RequestHandler;
   streamHandler?: StreamHandler;
 }
 
-export function createCustomHandler({
-  requestHandler = () => Promise.reject(),
-  streamHandler = (_, subscriber) => {
-    subscriber.error('unimplemented');
+const NAME = 'background';
+
+const backgroundPort: Port = {
+  name: NAME,
+  onMessage(listener) {
+    chrome.runtime.onMessage.addListener(listener);
+    return () => {
+      chrome.runtime.onMessage.removeListener(listener);
+    };
   },
-}: CustomHandlerOptions) {
-  const connections = new Set<Messaging>();
+  send(message, originMessage?: Parameters<Parameters<typeof chrome.runtime.onMessage.addListener>[0]>) {
+    if (!originMessage) return chrome.runtime.sendMessage(message);
+    const [, sender] = originMessage;
+    if (!sender.tab?.id) return chrome.runtime.sendMessage(message);
+    chrome.tabs.sendMessage(sender.tab.id, message, { documentId: sender.documentId, frameId: sender.frameId });
+  },
+};
 
-  const listener = (port: chrome.runtime.Port): void => {
-    if (!port.name.startsWith(NAMESPACE)) return;
-    const messaging = createMessaging(fromChromePort(port), {
-      async onRequest(message) {
-        if (!isWebxMessage(message)) return Promise.reject('unknown message');
-        const webxMessage = await applyMiddlewares(message, port);
+function shouldSkip(data: unknown) {
+  if (!isWebxMessage(data)) return true;
+  return !(!data.to || data.to === NAME);
+}
 
-        if (!webxMessage.to) return requestHandler(webxMessage);
-
-        for (const connection of connections) {
-          if (connection.name === port.name) continue;
-          if (connection.name.slice(NAMESPACE.length).startsWith(webxMessage.to)) {
-            return connection.request(webxMessage);
-          }
-        }
-
-        return Promise.reject('no target');
-      },
-      async onStream(message, subscriber) {
-        if (!isWebxMessage(message)) return subscriber.error('unknown message');
-        const webxMessage = await applyMiddlewares(message, port);
-
-        if (!webxMessage.to) return streamHandler(webxMessage, subscriber);
-
-        for (const connection of connections) {
-          if (connection.name === port.name) continue;
-          if (connection.name.slice(NAMESPACE.length).startsWith(webxMessage.to)) {
-            return connection.stream(webxMessage, subscriber);
-          }
-        }
-
-        subscriber.error('no target');
-      },
-      onDispose() {
-        connections.delete(messaging);
-      },
-    });
-    connections.add(messaging);
-  };
-  chrome.runtime.onConnect.addListener(listener);
-  return {
-    connections,
-    dispose() {
-      chrome.runtime.onConnect.removeListener(listener);
-    },
-  };
+export function createCustomHandler({ requestHandler, streamHandler }: CustomHandlerOptions) {
+  return createMessaging(backgroundPort, {
+    intercept: (data: WebxMessage, abort) => (shouldSkip(data) ? abort : data.data),
+    onRequest: requestHandler || (() => Promise.reject()),
+    onStream:
+      streamHandler ||
+      ((_, subscriber) => {
+        subscriber.error('unimplemented');
+      }),
+  });
 }
 
 export interface TrpcHandlerOptions<TRouter extends AnyTRPCRouter> {
@@ -95,24 +48,9 @@ export interface TrpcHandlerOptions<TRouter extends AnyTRPCRouter> {
 }
 
 export function createTrpcHandler<TRouter extends AnyTRPCRouter>({ router }: TrpcHandlerOptions<TRouter>) {
-  const connections = new Set<Messaging>();
-
-  const listener = (port: chrome.runtime.Port): void => {
-    if (!port.name.startsWith(NAMESPACE)) return;
-    const messaging = applyMessagingHandler({
-      port: fromChromePort(port),
-      router,
-      onDispose() {
-        connections.delete(messaging);
-      },
-    });
-    connections.add(messaging);
-  };
-  chrome.runtime.onConnect.addListener(listener);
-  return {
-    connections,
-    dispose() {
-      chrome.runtime.onConnect.removeListener(listener);
-    },
-  };
+  return applyMessagingHandler({
+    port: backgroundPort,
+    router,
+    intercept: (data: WebxMessage, abort) => (shouldSkip(data) ? abort : data.data),
+  });
 }

--- a/packages/messaging/src/content-script.ts
+++ b/packages/messaging/src/content-script.ts
@@ -2,13 +2,13 @@ import { AnyTRPCRouter } from '@trpc/server';
 import { SetOptional } from 'type-fest';
 import {
   CustomHandlerOptions,
-  TrpcHandlerOptions,
+  TrpcClientOptions,
   createCustomHandler as internalCreateCustomHandler,
-  createTrpcHandler as internalCreateTrpcHandler,
+  createTrpcClient as internalCreateTrpcClient,
 } from './client-base';
 
 export const createCustomHandler = (options: SetOptional<CustomHandlerOptions, 'type'>) =>
   internalCreateCustomHandler({ type: 'content-script', ...options });
 
-export const createTrpcHandler = <TRouter extends AnyTRPCRouter>(options: SetOptional<TrpcHandlerOptions, 'type'>) =>
-  internalCreateTrpcHandler<TRouter>({ type: 'content-script', ...options });
+export const createTrpcClient = <TRouter extends AnyTRPCRouter>(options: SetOptional<TrpcClientOptions, 'type'>) =>
+  internalCreateTrpcClient<TRouter>({ type: 'content-script', ...options });

--- a/packages/messaging/src/core/__tests__/index.spec.ts
+++ b/packages/messaging/src/core/__tests__/index.spec.ts
@@ -1,37 +1,8 @@
 import { setTimeout as sleep } from 'node:timers/promises';
 import { expect, it, vi } from 'vitest';
-import { Messaging, createMessaging, fromMessagePort } from '../index';
+import { createMessaging } from '../index';
 import { withResolvers } from '../utils';
-
-function expectMessagingIsNotLeaked(messaging: Messaging) {
-  // @ts-expect-error
-  expect(messaging.ongoingRequestResolvers).toHaveLength(0);
-  // @ts-expect-error
-  expect(messaging.ongoingStreamObservers).toHaveLength(0);
-}
-
-it('should on/off listener', async () => {
-  const { port1, port2 } = new MessageChannel();
-  const listenerFn = vi.fn();
-
-  const resolver = withResolvers<void>();
-  const receiver = createMessaging(fromMessagePort(port1), {
-    on: (...args) => {
-      listenerFn(...args);
-      resolver.resolve();
-    },
-  });
-
-  await (port2.postMessage('hello'), resolver.promise);
-  expect(listenerFn).toBeCalledTimes(1);
-  expect(listenerFn).toBeCalledWith('hello');
-
-  receiver.dispose();
-  await (port2.postMessage('hello'), sleep(10));
-  expect(listenerFn).toBeCalledTimes(1);
-
-  expectMessagingIsNotLeaked(receiver);
-});
+import { expectMessagingIsNotLeaked, fromMessagePort } from './test-utils';
 
 it('should support request', async () => {
   const { port1, port2 } = new MessageChannel();
@@ -156,97 +127,6 @@ it('should support abort stream', async () => {
 
   await sleep();
   expectMessagingIsNotLeaked(receiver);
-  expectMessagingIsNotLeaked(sender);
-});
-
-it('should support relay request', async () => {
-  const { port1, port2 } = new MessageChannel();
-  const { port1: port3, port2: port4 } = new MessageChannel();
-
-  const destination = createMessaging(fromMessagePort(port1), {
-    async onRequest(message) {
-      switch (message.name) {
-        case 'hello':
-          return await sleep(0, `Hello, ${message.user}`);
-        default:
-          throw new Error('Unknown method');
-      }
-    },
-  });
-  const relay1 = createMessaging(fromMessagePort(port2));
-  const relay2 = createMessaging(fromMessagePort(port3), {
-    onRequest() {
-      return this.relay(relay1);
-    },
-  });
-  const sender = createMessaging(fromMessagePort(port4));
-
-  await expect(sender.request({ name: 'hello', user: 'Tmk' })).resolves.toEqual('Hello, Tmk');
-  await expect(sender.request({ name: 'greet', user: 'Tmk' })).rejects.toThrow('Unknown method');
-
-  expectMessagingIsNotLeaked(destination);
-  expectMessagingIsNotLeaked(relay1);
-  expectMessagingIsNotLeaked(relay2);
-  expectMessagingIsNotLeaked(sender);
-});
-
-it('should support relay stream', async () => {
-  const { port1, port2 } = new MessageChannel();
-  const { port1: port3, port2: port4 } = new MessageChannel();
-
-  const destination = createMessaging(fromMessagePort(port1), {
-    async onStream(message, subscriber) {
-      switch (message.name) {
-        case 'hello': {
-          subscriber.next(1);
-          subscriber.next(2);
-          subscriber.next(3);
-          subscriber.complete();
-        }
-        default:
-          throw new Error('Unknown method');
-      }
-    },
-  });
-  const relay1 = createMessaging(fromMessagePort(port2));
-  const relay2 = createMessaging(fromMessagePort(port3), {
-    onStream() {
-      return this.relay(relay1);
-    },
-  });
-  const sender = createMessaging(fromMessagePort(port4));
-
-  await expect(
-    new Promise<unknown[]>((resolve, reject) => {
-      const result: unknown[] = [];
-      sender.stream(
-        { name: 'hello' },
-        {
-          next: (value) => result.push(value),
-          error: (reason) => reject(reason),
-          complete: () => resolve(result),
-        }
-      );
-    })
-  ).resolves.toEqual([1, 2, 3]);
-
-  await expect(
-    new Promise<unknown[]>((resolve, reject) => {
-      const result: unknown[] = [];
-      sender.stream(
-        { name: 'greet' },
-        {
-          next: (value) => result.push(value),
-          error: (reason) => reject(reason),
-          complete: () => resolve(result),
-        }
-      );
-    })
-  ).rejects.toThrow('Unknown method');
-
-  expectMessagingIsNotLeaked(destination);
-  expectMessagingIsNotLeaked(relay1);
-  expectMessagingIsNotLeaked(relay2);
   expectMessagingIsNotLeaked(sender);
 });
 

--- a/packages/messaging/src/core/__tests__/test-utils.ts
+++ b/packages/messaging/src/core/__tests__/test-utils.ts
@@ -1,0 +1,20 @@
+import { expect } from 'vitest';
+import { Messaging, Port } from '../index';
+
+export function fromMessagePort(port: MessagePort): Port {
+  return {
+    send: (message) => port.postMessage(message),
+    onMessage(listener) {
+      const ac = new AbortController();
+      port.addEventListener('message', (ev) => listener(ev.data), { signal: ac.signal });
+      return ac.abort.bind(ac);
+    },
+  };
+}
+
+export function expectMessagingIsNotLeaked(messaging: Messaging) {
+  // @ts-expect-error
+  expect(messaging.ongoingRequestResolvers).toHaveLength(0);
+  // @ts-expect-error
+  expect(messaging.ongoingStreamObservers).toHaveLength(0);
+}

--- a/packages/messaging/src/shared.ts
+++ b/packages/messaging/src/shared.ts
@@ -1,19 +1,14 @@
 import type { LiteralUnion, Observer } from 'type-fest';
-
-export const NAMESPACE = 'webx:';
+import { Messaging } from './core';
 
 export type ClientType = 'devtools' | 'popup' | 'options' | 'content-script';
 
-export type MessageTarget = LiteralUnion<ClientType, string>;
+export type MessageTarget = LiteralUnion<ClientType, string> | number;
 
 export type RequestHandler = (message: WebxMessage) => any;
 export type StreamHandler = (message: WebxMessage, subscriber: Observer<any>) => any;
 
 export interface WebxMessage {
-  /** Source ID */
-  from?: string;
-  /** Source tab ID */
-  tabId?: number;
   /** Target */
   to?: MessageTarget;
   /** Structural cloneable data */
@@ -23,3 +18,23 @@ export interface WebxMessage {
 export function isWebxMessage(message: unknown): message is WebxMessage {
   return typeof message === 'object' && message !== null && 'data' in message;
 }
+
+export function wrapMessaging(messaging: Messaging) {
+  return {
+    request(data: unknown) {
+      return messaging.request({ data } satisfies WebxMessage);
+    },
+    stream(data: unknown, observer: Partial<Observer<any>>) {
+      return messaging.stream({ data } satisfies WebxMessage, observer);
+    },
+    requestTo(to: MessageTarget, data: unknown) {
+      return messaging.request({ data, to } satisfies WebxMessage);
+    },
+    streamTo(to: MessageTarget, data: unknown, observer: Partial<Observer<any>>) {
+      return messaging.stream({ data, to } satisfies WebxMessage, observer);
+    },
+    dispose: messaging.dispose,
+  };
+}
+
+export type WrappedMessaging = ReturnType<typeof wrapMessaging>;


### PR DESCRIPTION
There are some glitches in [Long-lived connections](https://developer.chrome.com/docs/extensions/develop/concepts/messaging#connect)

1. The background service worker will become inactive if there are no activities for a certain period of time. We need to reconnect after it has been disconnected.
2. When the background is inactive while the page is paused (e.g., during debugging), onDisconnect will not be triggered, leading to the state not being reset.