### PR TITLE
feat: suppress 404 for hot-update files

### DIFF
--- a/packages/modernjs-plugin/src/index.ts
+++ b/packages/modernjs-plugin/src/index.ts
@@ -35,6 +35,17 @@ const getDefaultConfig = ({ allInOneEntries }: { allInOneEntries: Set<string> })
     html: {
       disableHtmlFolder: true,
     },
+    bff: {
+      proxy: {
+        '/': {
+          target: 'https://www.example.com/',
+          onProxyReq(_proxyReq, req, res) {
+            // @ts-expect-error suppress 404 for hot-update files
+            if (req.url.includes('.hot-update.')) res.end('');
+          },
+        },
+      },
+    },
     output: {
       disableInlineRuntimeChunk: true, // inline scripts are not allowed in MV3
       disableFilenameHash: true,


### PR DESCRIPTION
An error will occur if a tab still loads the old content scripts code.

```
Web Server Error - Page could not be found, error = 404 Not Found, req.url = /csui.9781d4552e706cac.hot-update.json, req.headers = {
  host: 'localhost:9001',
  connection: 'keep-alive',
  'sec-ch-ua': '"Not A(Brand";v="99", "Microsoft Edge";v="121", "Chromium";v="121"',
  'sec-ch-ua-mobile': '?0',
  'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36 Edg/121.0.0.0',
  'sec-ch-ua-platform': '"macOS"',
  accept: '*/*',
  origin: 'http://localhost:3000',
  'sec-fetch-site': 'same-site',
  'sec-fetch-mode': 'cors',
  'sec-fetch-dest': 'empty',
  referer: 'http://localhost:3000/',
  'accept-encoding': 'gzip, deflate, br',
  'accept-language': 'zh-CN,zh;q=0.9,fr;q=0.8,th;q=0.7,en;q=0.6,ja;q=0.5,es-MX;q=0.4,es;q=0.3,ar;q=0.2,en-GB;q=0.1,en-US;q=0.1'
}
```